### PR TITLE
Fix #IDEUI-197 ability to style part icon

### DIFF
--- a/codenvy-ext-datasource-client-widget/src/main/java/com/codenvy/ide/ext/datasource/client/common/TextEditorPartAdapter.java
+++ b/codenvy-ext-datasource-client-widget/src/main/java/com/codenvy/ide/ext/datasource/client/common/TextEditorPartAdapter.java
@@ -37,6 +37,7 @@ import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.SimpleLayoutPanel;
 import com.google.web.bindery.event.shared.EventBus;
 
+import org.vectomatic.dom.svg.ui.SVGImage;
 import org.vectomatic.dom.svg.ui.SVGResource;
 
 import javax.annotation.Nullable;
@@ -177,6 +178,12 @@ public class TextEditorPartAdapter<T extends TextEditorPartPresenter> implements
     @Override
     public ImageResource getTitleImage() {
         return this.editor.getTitleImage();
+    }
+
+    @Nullable
+    @Override
+    public SVGImage decorateIcon(SVGImage svgImage) {
+        return svgImage;
     }
 
     @Override


### PR DESCRIPTION
Add needed decorateIcon method to TextEditorPartAdapter following
evolution of PartPresenter interface in ide.
