### PR TITLE
IDEX-1772. Fixed css for button 'delete brokers' for Firefox browser

### DIFF
--- a/codenvy-ext-datasource-client/src/main/java/com/codenvy/ide/ext/datasource/client/newdatasource/connector/nuodb/NuoDBDatasourceConnectorViewImpl.ui.xml
+++ b/codenvy-ext-datasource-client/src/main/java/com/codenvy/ide/ext/datasource/client/newdatasource/connector/nuodb/NuoDBDatasourceConnectorViewImpl.ui.xml
@@ -24,7 +24,8 @@
 			background-color: #313131;
 			font-weight: normal;
             margin-left: 8px;
-            margin-top: 3px;	
+            margin-top: 3px;
+            white-space: nowrap;
         }
         
         .marginLeft {


### PR DESCRIPTION
IDEX-1772. Button "Delete brokers" incorrect displays in the Firefox, so was corrected css style.
